### PR TITLE
fix: adicionado opção de comando terraform plan 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ terraform init
 terraform apply
 ```
 
+  - OBS: Opicionalmente, você pode utilizar o comando `terraform plan` para visualizar as alterações que serão realizadas antes de executar o `terraform apply`. Com os seguintes comandos:
+
+```
+terraform plan -out=oci.tfplan
+terraform apply "oci.tf.plan" -auto-approve
+```
+
 6. Acesse o cluster.
 
 ```


### PR DESCRIPTION
Foi adicionado um comando opcional ao item 5, `Criando o Cluster` no README do projeto.

![image](https://github.com/Rapha-Borges/oke-free/assets/19556950/e6ccfa0b-4080-47b6-89c5-3b48081016f3)

Trata-se de uma mudança para melhor visualizar as modificações, durante a criação do cluster.
