### PR TITLE
Corrige a extensão do arquivo oci.tfplan na instrução do comando terraform apply do passo 5 do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ terraform apply
 
 ```
 terraform plan -out=oci.tfplan
-terraform apply "oci.tf.plan" -auto-approve
+terraform apply "oci.tfplan" -auto-approve
 ```
 
 6. Acesse o cluster.


### PR DESCRIPTION
Estou adicionando essa pull request para corrigir a extensão do arquivo oci.tfplan na instrução do passo 5 do README:
```
terraform plan -out=oci.tfplan
terraform apply "oci.tfplan" -auto-approve
```