### PR TITLE
Update network security rules #5

### DIFF
--- a/network/network.tf
+++ b/network/network.tf
@@ -34,43 +34,43 @@ resource "oci_core_security_list" "public_subnet_sl" {
 
   ingress_security_rules {
     stateless   = false
-    source      = "0.0.0.0/0"
+    source      = "10.0.0.0/16"
     source_type = "CIDR_BLOCK"
     protocol    = "all"
   }
 
-#   ingress_security_rules {
-#     stateless   = false
-#     source      = "0.0.0.0/0"
-#     source_type = "CIDR_BLOCK"
-#     protocol    = "6"
-#     tcp_options {
-#       min = 6443
-#       max = 6443
-#     }
-#   }
+  ingress_security_rules {
+    stateless   = false
+    source      = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+    protocol    = "6"
+    tcp_options {
+      min = 6443
+      max = 6443
+    }
+  }
 
-#   ingress_security_rules {
-#     stateless   = false
-#     source      = "0.0.0.0/0"
-#     source_type = "CIDR_BLOCK"
-#     protocol    = "6"
-#     tcp_options {
-#       min = 80
-#       max = 80
-#     }
-#   }
+  ingress_security_rules {
+    protocol    = "6"
+    source      = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+    stateless   = false
+    tcp_options {
+      max = 80
+      min = 80
+    }
+  }
 
-#   ingress_security_rules {
-#     stateless   = false
-#     source      = "0.0.0.0/0"
-#     source_type = "CIDR_BLOCK"
-#     protocol    = "6"
-#     tcp_options {
-#       min = 443
-#       max = 443
-#     }
-#   }
+  ingress_security_rules {
+    protocol    = "6"
+    source      = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+    stateless   = false
+    tcp_options {
+      max = 443
+      min = 443
+    }
+  }
 }
 
 resource "oci_core_subnet" "vcn_private_subnet" {


### PR DESCRIPTION
Restaure as configurações de ingress/egress da subnet pública para os padrões. Portas de entrada autorizadas:

- 80
- 443
- 6443