### PR TITLE
Atualização sobre diretório temp e do SSH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ id_rsa*
 # Ignore output shell
 output-gen*
 tfplan
+
+# Directory for sensible files and external files: i.e. env.sh / deployment.yaml
+temp

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ id_rsa*
 output-gen*
 tfplan
 
+# file with credentials
+env.sh
+
 # Directory for sensible files and external files: i.e. env.sh / deployment.yaml
 temp

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ ssh-keygen -t rsa -b 4096 -f ./ssh/id_rsa
 - GNU/Linux
 
 ```
-vim ./temp/env.sh
+vim ./env.sh
 ```
 
 ```
@@ -199,7 +199,7 @@ export TF_VAR_oci_profile="DEFAULT"
 Agora rode o script para exportar as variáveis:
 
 ```
-source ./temp/env.sh
+source ./env.sh
 ```
 
 - Windows

--- a/README.md
+++ b/README.md
@@ -172,18 +172,18 @@ region=xxxxxxxx
 key_file=C:\Users\<user>\.oci\oci_api_key.pem
 ```
 
-7. Crie a pasta `/ssh` e gere a chave `ssh` (No Windows, utilize o [Git Bash](https://git-scm.com/downloads) para executar o comando abaixo).
+7. Crie a pasta `./ssh` e gere a chave `ssh` (No Windows, utilize o [Git Bash](https://git-scm.com/downloads) para executar o comando abaixo).
 
 ```bash
-ssh-keygen -t rsa -b 4096 -f ssh/id_rsa
+ssh-keygen -t rsa -b 4096 -f ./ssh/id_rsa
 ```
 
-8. Crie o arquivo com as variáveis de ambiente, substituindo os valores das variáveis pelos valores da sua conta.
+8. Crie o arquivo com as variáveis de ambiente, substituindo os valores das variáveis pelos valores da sua conta (o conteúdo usado no arquivo ~/.oci/config acima).
 
 - GNU/Linux
 
 ```
-vim env.sh
+vim ./temp/env.sh
 ```
 
 ```
@@ -199,7 +199,7 @@ export TF_VAR_oci_profile="DEFAULT"
 Agora rode o script para exportar as variáveis:
 
 ```
-source env.sh
+source ./temp/env.sh
 ```
 
 - Windows


### PR DESCRIPTION
[.gitignore](.gitignore)
Criado um diretório ./temp onde ficariam os arquivos temporarios e sensiveis como:
```
./temp/env.sh
./temp/meu_deployment_test.yaml
```
 --------------------
[README.md](README.md)

atualizado o README sobre a pasta de criação dos arquivos ssh que poderia confundir como sendo o diretório RAIZ quando o correto é o diretório atual.