### PR TITLE
Refactored code to fix the backend definition

### DIFF
--- a/loadbalancer/loadbalancer.tf
+++ b/loadbalancer/loadbalancer.tf
@@ -1,5 +1,5 @@
-data "oci_core_instances" "instances" {
-  compartment_id = var.compartment_id
+data "oci_containerengine_node_pool" "oke_node_pool" {
+  node_pool_id   = var.node_pool_id
 }
 
 resource "oci_network_load_balancer_network_load_balancer" "nlb" {
@@ -40,8 +40,8 @@ resource "oci_network_load_balancer_backend" "nlb_backend_http" {
   network_load_balancer_id = oci_network_load_balancer_network_load_balancer.nlb.id
   port                     = var.node_port_http
   depends_on               = [oci_network_load_balancer_backend_set.nlb_backend_set_http]
-  count                    = var.node_size
-  target_id                = data.oci_core_instances.instances.instances[count.index].id
+  count                    = length(data.oci_containerengine_node_pool.oke_node_pool.nodes)
+  target_id                = data.oci_containerengine_node_pool.oke_node_pool.nodes[count.index].id
 }
 
 resource "oci_network_load_balancer_backend" "nlb_backend_https" {
@@ -49,8 +49,8 @@ resource "oci_network_load_balancer_backend" "nlb_backend_https" {
   network_load_balancer_id = oci_network_load_balancer_network_load_balancer.nlb.id
   port                     = var.node_port_https
   depends_on               = [oci_network_load_balancer_backend_set.nlb_backend_set_https]
-  count                    = var.node_size
-  target_id                = data.oci_core_instances.instances.instances[count.index].id
+  count                    = length(data.oci_containerengine_node_pool.oke_node_pool.nodes)
+  target_id                = data.oci_containerengine_node_pool.oke_node_pool.nodes[count.index].id
 }
 
 resource "oci_network_load_balancer_listener" "nlb_listener_http" {


### PR DESCRIPTION
This pull request includes significant updates to the `loadbalancer/loadbalancer.tf` file, primarily focusing on switching from using `oci_core_instances` to `oci_containerengine_node_pool` for managing node pools and updating related configurations.

### Changes to Node Pool Management:

* Replaced `oci_core_instances` with `oci_containerengine_node_pool` for defining node pools. (`loadbalancer/loadbalancer.tf`)
* Updated the `count` and `target_id` attributes in the `oci_network_load_balancer_backend` resources to reference the new `oci_containerengine_node_pool` data source. This ensures that the load balancer backend targets the correct nodes from the node pool. (`loadbalancer/loadbalancer.tf`) #50 